### PR TITLE
shell: remove Popen.wait() call

### DIFF
--- a/hubble/shell.py
+++ b/hubble/shell.py
@@ -343,7 +343,6 @@ def main():
             if len(environments) != 1:
                 print("-- [%s] --" % green(env))
             # Wait for the command to complete
-            p.wait()
             stdout, stderr = p.communicate()
             sys.stdout.write(stdout)
             sys.stderr.write(stderr)


### PR DESCRIPTION
https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait

If the PIPE buffer fills, the child could block on a write to stdout, which causes a deadlock.
