### PR TITLE
travis: use tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 language: python
-python:
-  - "2.7"
-  - "3.5"
-install:
- - pip install -r requirements.txt
- - pip install -e .
-script:
- - py.test
+before_script:
+  - pip install tox
+
+script: tox
+notifications:
+  on_success: change
+  on_failure: always
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.5
+      env: TOXENV=flake8

--- a/hubble/config.py
+++ b/hubble/config.py
@@ -12,10 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from configparser import _UNSET, NoOptionError, NoSectionError, RawConfigParser
 from itertools import chain
 import os
 
+from backports.configparser import _UNSET, \
+    NoOptionError, NoSectionError, RawConfigParser
 from six import string_types
 
 

--- a/hubble/keys.py
+++ b/hubble/keys.py
@@ -18,9 +18,11 @@
 from __future__ import print_function
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
-from hubble.config import validate_variable_exists
-import keyring
 import getpass
+
+import keyring
+
+from hubble.config import validate_variable_exists
 
 
 def main():

--- a/hubble/shell.py
+++ b/hubble/shell.py
@@ -15,13 +15,14 @@
 from __future__ import print_function
 
 import argparse
-from configparser import NoOptionError, NoSectionError
 import logging
 import os
 import re
 from subprocess import CalledProcessError, check_output, PIPE, Popen
 import sys
 import textwrap
+
+from backports.configparser import NoOptionError, NoSectionError
 
 from hubble.config import read_configs
 

--- a/hubble/shell.py
+++ b/hubble/shell.py
@@ -14,15 +14,16 @@
 
 from __future__ import print_function
 
-from subprocess import check_output, CalledProcessError, Popen, PIPE
-from configparser import NoSectionError
-from hubble.config import read_configs
 import argparse
-import textwrap
+from configparser import NoOptionError, NoSectionError
 import logging
-import sys
-import re
 import os
+import re
+from subprocess import CalledProcessError, check_output, PIPE, Popen
+import sys
+import textwrap
+
+from hubble.config import read_configs
 
 try:
     # Not everyone needs keyring

--- a/hubble/tests/unit/test_hubble.py
+++ b/hubble/tests/unit/test_hubble.py
@@ -12,12 +12,13 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-
-from hubble.shell import get_environments, Env, run, to_dict, empty
-from hubble.config import parse_configs
-from six.moves import StringIO
-import unittest
 import argparse
+import unittest
+
+from six.moves import StringIO
+
+from hubble.config import parse_configs
+from hubble.shell import empty, Env, get_environments, run, to_dict
 
 
 class TestEnv(unittest.TestCase):
@@ -35,7 +36,8 @@ class TestEnv(unittest.TestCase):
         env.set('first', 'Derrick', 'section')
         env.set('last', 'Wippler', 'section')
         env.set('no-export', 'wat', 'section', export=False)
-        self.assertEqual(env.to_dict(), {'first': 'Derrick', 'last': 'Wippler'})
+        expected = {'first': 'Derrick', 'last': 'Wippler'}
+        self.assertEqual(env.to_dict(), expected)
 
     def test_get_environments(self):
         parser = argparse.ArgumentParser()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,9 @@
-flake8>=2.5.4
 pytest>=2.9.2
+
+# pytest plugins
+pytest-flake8>=0.5
+pytest-cov>=2.3.0
+
+# flake8 plugins
 pep8-naming>=0.4.1
 flake8-import-order>=0.8

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,23 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, pep8
+envlist = py27, py34, py35, flake8
 skip_missing_interpreters = True
 
 [testenv]
 setenv =
     TOXDIR = {toxinidir}
-commands = py.test
+commands = py.test -v --cov=hubble --cov-report=term-missing hubble
 deps = -r{toxinidir}/test-requirements.txt
 
-[testenv:pep8]
+[testenv:flake8]
+basepython = python3
+skip_install = true
 commands =
     flake8 {posargs} .
+
+[flake8]
+ignore = E731
+#max-complexity = 10
+import-order-style = google
+application-import-names = hubble


### PR DESCRIPTION
This also fixes most outstanding flake8 issues, enables flake8 gate testing, and shows a coverage report while running tests (maybe we disable this later in favor of whatever happens during #13).

---

I noticed py34 is actually failing. I think there are two ways to fix this:
- drop py34 support
- use the `from backports import configparser` invocation to use the pypi version of configparser on python3 as well (currently only python2 uses pypi's configparser).

I'm in favor of dropping all the things, but if you think py34 is important, we can easily do the other thing.
